### PR TITLE
B/1 launches details timezone tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
     "emotion-theming": "^10.0.27",
+    "luxon": "^1.25.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-feather": "^2.0.8",

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -23,7 +23,7 @@ import {
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime, formatUserLocalDateTime } from "../utils/format-date";
+import { formatUTCOffsetDateTime, formatUserLocalDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -126,7 +126,7 @@ function TimeAndLocation({ launch }) {
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
           <Tooltip hasArrow label={'Your local time: ' + formatUserLocalDateTime(launch.launch_date_utc)}>
-            {formatDateTime(launch.launch_date_local)}
+            {formatUTCOffsetDateTime(launch.launch_date_local)}
           </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -13,6 +13,7 @@ import {
   SimpleGrid,
   Box,
   Text,
+  Tooltip,
   Spinner,
   Image,
   Link,
@@ -124,7 +125,9 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip hasArrow label={'Your local time: ' + formatDateTime(launch.launch_date_local)}>
+            {formatDateTime(launch.launch_date_local)}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -23,7 +23,7 @@ import {
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatUserLocalDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -125,7 +125,7 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          <Tooltip hasArrow label={'Your local time: ' + formatDateTime(launch.launch_date_local)}>
+          <Tooltip hasArrow label={'Your local time: ' + formatUserLocalDateTime(launch.launch_date_utc)}>
             {formatDateTime(launch.launch_date_local)}
           </Tooltip>
         </StatNumber>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -20,3 +20,18 @@ export function formatUserLocalDateTime(timestamp) {
     timeZoneName: "short",
   }).format(new Date(timestamp));
 }
+
+export function formatUTCOffsetDateTime(timestamp) {
+  const timestampFormatted = new Intl.DateTimeFormat(navigator.language, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    timeZone: "UTC"
+  }).format(new Date(timestamp));
+  const timestampUTC = DateTime.fromISO(timestamp, { setZone: true })
+  const offset = timestampUTC.zoneName
+  return `${timestampFormatted} ${offset}`
+}

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -9,8 +9,8 @@ export function formatDate(timestamp) {
   }).format(new Date(timestamp));
 }
 
-export function formatDateTime(timestamp) {
-  return new Intl.DateTimeFormat("en-US", {
+export function formatUserLocalDateTime(timestamp) {
+  return new Intl.DateTimeFormat(navigator.language, {
     year: "numeric",
     month: "long",
     day: "numeric",

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,3 +1,5 @@
+const { DateTime } = require("luxon");
+
 export function formatDate(timestamp) {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "long",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6621,6 +6621,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+luxon@^1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.25.0.tgz#d86219e90bc0102c0eb299d65b2f5e95efe1fe72"
+  integrity sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
## **Documentation:**

You can access the documentation at the following link:
[Task 1](./CHALLENGE.md)
[Luxon](https://github.com/moment/luxon)

---

## **Basic requirements:**

Basic requirement: 
The team discovered that the launch datetime on the launch details page (e.g. /launches/92) is displayed in the timezone of the app's user. However, the intent was to show it in the local timezone of the launch site instead (still displaying the timezone name or offset). After a discussion the team decided to make the change, but keep the time in the user's timezone as a tooltip when hovering the timestamp. You pick up that ticket.

Guidelines for Task 1
treat this as if you fixed a bug in an app you work on together with a team, and the app is in production

---

## **Testing:**

Here are the steps to test this feature: *

1. Open the application and head to the launch details page (e.g. /launches/92). 
2. Hover the timestamp to see the tooltip.

![image](https://user-images.githubusercontent.com/24980999/98024886-f70d8f80-1dd6-11eb-8283-7947d599d48d.png)
Acceptance Criteria:
- The user's timezone should appear in the tooltip
- The local timezone of the launch pad should be displayed with the UTC +/- offset

---

## **Troubleshooting:**

In case something goes wrong:
Clear your cache and refresh the page. Contact Devan if still experiencing issues.